### PR TITLE
CalDAV/CardDAV detection: Make list of negative matches against User-Agent configurable

### DIFF
--- a/roles/apache2/defaults/main.yml
+++ b/roles/apache2/defaults/main.yml
@@ -86,3 +86,7 @@ apache2_dav_agent_strings:
   - OX Sync
   - CalDav
   - CoreDAV
+
+apache2_dav_agent_strings_exclude:
+  - Thunderbird ActiveSync
+  - Open-Xchange Calendar Feed Client

--- a/roles/apache2/templates/etc/apache2/sites-available/oxappsuite.conf.j2
+++ b/roles/apache2/templates/etc/apache2/sites-available/oxappsuite.conf.j2
@@ -206,7 +206,10 @@
 	RewriteCond %{HTTP_USER_AGENT} "{{ agent }}" {% if not loop.last %}[OR]{% endif %}
 
 {% endfor %}
-	RewriteCond %{HTTP_USER_AGENT} "!Open-Xchange Calendar Feed Client"
+{% for agent in apache2_dav_agent_strings_exclude %}
+	RewriteCond %{HTTP_USER_AGENT} "!{{ agent }}"
+
+{% endfor %}
 	RewriteRule (.*) http://localhost:8009/servlet/dav$1 [P]
 
 	RewriteCond %{REQUEST_URI} ^/\.well-known/caldav   [OR]


### PR DESCRIPTION
- Make list of user agents strings to exclude from CalDAV/CardDAV redirection configurable
- Add `Thunderbird ActiveSync` to the default exclude list, as `Thunderbird` already is on the default include list.